### PR TITLE
first trial pull request - added gitignore for C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/p1.cpp
+++ b/p1.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <assert.h>
+#include <math.h>
 using namespace std;
 
 int count(int top){
@@ -13,8 +14,9 @@ int count(int top){
 }
       
 int main(){
-  //cout << count(1000) << endl;
-  assert(count(10) == 22);
-  return 1;
+  assert(count(10) == 23);
+  assert(count(1000) == 233168);
+  cout << count(1000) << endl;
+  return 0;
 }
 


### PR DESCRIPTION
you need the .gitignore file to make it easier to use git. git add will now skip over things like a.out and such, so you don't accidentally check in executable files (which would be a waste).

I also made some silly changes to p1.cpp
